### PR TITLE
From GeoZero (reverse conversion)

### DIFF
--- a/src/geometry/linestring.rs
+++ b/src/geometry/linestring.rs
@@ -63,6 +63,11 @@ impl<'a, T: Coord> LineString<'a, T> {
         self.coords.to_mut().push(coord);
     }
 
+    /// Extends the LineString with coordinates.
+    pub fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.coords.to_mut().extend(iter);
+    }
+
     /// Removes all points from the LineString.
     pub fn clear(&mut self) {
         self.coords.to_mut().clear();

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 mod linestring;
 mod multi_linestring;
 mod multi_point;
@@ -55,6 +57,7 @@ pub enum Geometry<'a, T: Coord> {
     MultiPolygon(MultiPolygon<'a, T>),
     // Triangle?
     // TIN?
+    GeometryCollection(Vec<Geometry<'a, T>>),
 }
 
 pub type Geometry2<'a, C = f64> = Geometry<'a, [C; 2]>;

--- a/src/geometry/multi_point.rs
+++ b/src/geometry/multi_point.rs
@@ -69,6 +69,11 @@ impl<'a, T: Coord> MultiPoint<'a, T> {
         self.coords.to_mut().push(coord);
     }
 
+    /// Extends the MultiPoint with coordinates.
+    pub fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.coords.to_mut().extend(iter);
+    }
+
     /// Removes all points from the LineString.
     pub fn clear(&mut self) {
         self.coords.to_mut().clear();

--- a/src/geozero/mod.rs
+++ b/src/geozero/mod.rs
@@ -1,2 +1,20 @@
-mod reader;
-mod writer;
+pub mod reader;
+pub mod writer;
+
+use alloc::string::ToString;
+use geozero::error::{GeozeroError, Result};
+use geozero::GeozeroGeometry;
+
+pub trait ToFlatgeom<const D: usize> {
+    fn to_flatgeom(&self) -> Result<crate::Geometry<[f64; D]>>;
+}
+
+impl<const D: usize, T: GeozeroGeometry> ToFlatgeom<D> for T {
+    fn to_flatgeom(&self) -> Result<crate::Geometry<[f64; D]>> {
+        let mut writer = writer::FlatgeomWriter::<D>::new();
+        self.process_geom(&mut writer)?;
+        writer
+            .take_geometry()
+            .ok_or(GeozeroError::Geometry("Missing geometry".to_string()))
+    }
+}

--- a/src/geozero/writer.rs
+++ b/src/geozero/writer.rs
@@ -123,6 +123,10 @@ impl<const D: usize> GeomProcessor for FlatgeomWriter<D> {
     }
 
     fn geometrycollection_end(&mut self, _idx: usize) -> Result<()> {
+        let Some(collection) = self.collections.pop() else {
+            panic!("collection stack underflow");
+        };
+        self.current = Some(Geometry::GeometryCollection(collection));
         self.finish_geometry();
         Ok(())
     }

--- a/src/geozero/writer.rs
+++ b/src/geozero/writer.rs
@@ -1,1 +1,189 @@
+use alloc::vec::Vec;
 
+use geozero::error::Result;
+use geozero::GeomProcessor;
+
+use crate::{Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Polygon};
+
+pub struct FlatgeomWriter<const D: usize> {
+    geoms: Vec<Geometry<'static, [f64; D]>>,
+    collections: Vec<Vec<Geometry<'static, [f64; D]>>>, // stack of GeometryCollection (nested)
+    current: Option<Geometry<'static, [f64; D]>>,
+    coords: Vec<[f64; D]>,
+}
+
+impl<const D: usize> FlatgeomWriter<D> {
+    pub fn new() -> Self {
+        if D < 2 {
+            panic!("Dimension must be at least 2")
+        }
+        Self {
+            geoms: Vec::with_capacity(1),
+            collections: Vec::with_capacity(1),
+            current: None,
+            coords: Vec::new(),
+        }
+    }
+
+    pub fn take_geometry(mut self) -> Option<Geometry<'static, [f64; D]>> {
+        match self.geoms.len() {
+            0 => None,
+            1 => Some(self.geoms.pop().unwrap()),
+            _ => Some(Geometry::GeometryCollection(self.geoms)),
+        }
+    }
+}
+
+impl<const D: usize> Default for FlatgeomWriter<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const D: usize> FlatgeomWriter<D> {
+    fn start_geometry(&mut self, geom: Geometry<'static, [f64; D]>) {
+        match geom {
+            Geometry::GeometryCollection(geoms) => {
+                self.collections.push(geoms);
+            }
+            geom => {
+                self.current = Some(geom);
+            }
+        }
+    }
+
+    fn finish_coords(&mut self, idx: usize) {
+        if let Some(geom) = self.current.as_mut() {
+            let iter = self.coords.iter().copied();
+            match geom {
+                Geometry::MultiPoint(mp) => mp.extend(iter),
+                Geometry::LineString(ls) => ls.extend(iter),
+                Geometry::MultiLineString(mls) => mls.add_linestring(iter),
+                Geometry::Polygon(poly) => poly.add_ring(iter),
+                Geometry::MultiPolygon(mpoly) => {
+                    if idx == 0 {
+                        mpoly.add_exterior(iter);
+                    } else {
+                        mpoly.add_interior(iter);
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.coords.clear();
+    }
+
+    fn finish_geometry(&mut self) {
+        if let Some(last) = self.collections.last_mut() {
+            last.push(self.current.take().unwrap());
+        } else {
+            self.geoms.push(self.current.take().unwrap());
+        }
+    }
+}
+
+impl<const D: usize> GeomProcessor for FlatgeomWriter<D> {
+    fn multi_dim(&self) -> bool {
+        D >= 3
+    }
+
+    fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
+        let mut coord = [0.; D];
+        coord[0] = x;
+        coord[1] = y;
+        self.coords.push(coord);
+        Ok(())
+    }
+
+    fn coordinate(
+        &mut self,
+        x: f64,
+        y: f64,
+        z: Option<f64>,
+        _m: Option<f64>,
+        _t: Option<f64>,
+        _tm: Option<u64>,
+        _idx: usize,
+    ) -> Result<()> {
+        let mut coord = [0.; D];
+        coord[0] = x;
+        coord[1] = y;
+        if D >= 3 {
+            if let Some(z) = z {
+                coord[2] = z;
+            }
+        }
+        self.coords.push(coord);
+        Ok(())
+    }
+
+    fn geometrycollection_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
+        self.start_geometry(Geometry::GeometryCollection(Vec::new()));
+        Ok(())
+    }
+
+    fn geometrycollection_end(&mut self, _idx: usize) -> Result<()> {
+        self.finish_geometry();
+        Ok(())
+    }
+
+    fn multipoint_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
+        self.start_geometry(Geometry::MultiPoint(MultiPoint::new()));
+        Ok(())
+    }
+
+    fn linestring_begin(&mut self, tagged: bool, _size: usize, _idx: usize) -> Result<()> {
+        if tagged {
+            self.start_geometry(Geometry::LineString(LineString::new()));
+        }
+        Ok(())
+    }
+
+    fn multilinestring_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
+        self.start_geometry(Geometry::MultiLineString(MultiLineString::new()));
+        Ok(())
+    }
+
+    fn polygon_begin(&mut self, tagged: bool, _size: usize, _idx: usize) -> Result<()> {
+        if tagged {
+            self.start_geometry(Geometry::Polygon(Polygon::new()));
+        }
+        Ok(())
+    }
+
+    fn multipolygon_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
+        self.start_geometry(Geometry::MultiPolygon(MultiPolygon::new()));
+        Ok(())
+    }
+
+    fn multipoint_end(&mut self, idx: usize) -> Result<()> {
+        self.finish_coords(idx);
+        self.finish_geometry();
+        Ok(())
+    }
+
+    fn linestring_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
+        self.finish_coords(idx);
+        if tagged {
+            self.finish_geometry();
+        }
+        Ok(())
+    }
+
+    fn multilinestring_end(&mut self, _idx: usize) -> Result<()> {
+        self.finish_geometry();
+        Ok(())
+    }
+
+    fn polygon_end(&mut self, tagged: bool, _idx: usize) -> Result<()> {
+        if tagged {
+            self.finish_geometry();
+        }
+        Ok(())
+    }
+
+    fn multipolygon_end(&mut self, _idx: usize) -> Result<()> {
+        self.finish_geometry();
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@
 extern crate alloc;
 
 mod geometry;
-mod geozero;
+pub mod geozero;
 
 pub use geometry::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 extern crate alloc;
 
 mod geometry;
+
+#[cfg(feature = "geozero")]
 pub mod geozero;
 
 pub use geometry::*;

--- a/tests/geozero.rs
+++ b/tests/geozero.rs
@@ -318,7 +318,13 @@ fn geometry3d() {
 fn geometry_collection() {
     let mut mp = MultiPoint2::new();
     mp.extend([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]);
-    let geomcoll = crate::Geometry2::GeometryCollection(vec![crate::Geometry2::MultiPoint(mp)]);
+
+    let ls = LineString2::from_raw(vec![[0., 0.], [5., 0.], [5., 5.], [0., 5.]].into());
+
+    let geomcoll = crate::Geometry2::GeometryCollection(vec![
+        crate::Geometry2::MultiPoint(mp),
+        crate::Geometry2::LineString(ls),
+    ]);
 
     // Conversion
     let Ok(geo) = geomcoll.to_geo() else {
@@ -326,7 +332,7 @@ fn geometry_collection() {
     };
     match &geo {
         geo_types::Geometry::GeometryCollection(geo_geomcoll) => {
-            assert_eq!(geo_geomcoll.len(), 1);
+            assert_eq!(geo_geomcoll.len(), 2);
         }
         _ => panic!("Geometry type must be GeometryCollection"),
     }
@@ -337,7 +343,7 @@ fn geometry_collection() {
     };
     match &flat {
         flatgeom::Geometry::GeometryCollection(mp) => {
-            assert_eq!(mp.len(), 1);
+            assert_eq!(mp.len(), 2);
         }
         _ => panic!("GeometryCollection is expected"),
     }

--- a/tests/geozero.rs
+++ b/tests/geozero.rs
@@ -313,3 +313,32 @@ fn geometry3d() {
         _ => panic!("MultiPoint is expected"),
     }
 }
+
+#[test]
+fn geometry_collection() {
+    let mut mp = MultiPoint2::new();
+    mp.extend([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]);
+    let geomcoll = crate::Geometry2::GeometryCollection(vec![crate::Geometry2::MultiPoint(mp)]);
+
+    // Conversion
+    let Ok(geo) = geomcoll.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::GeometryCollection(geo_geomcoll) => {
+            assert_eq!(geo_geomcoll.len(), 1);
+        }
+        _ => panic!("Geometry type must be GeometryCollection"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::GeometryCollection(mp) => {
+            assert_eq!(mp.len(), 1);
+        }
+        _ => panic!("GeometryCollection is expected"),
+    }
+}

--- a/tests/geozero.rs
+++ b/tests/geozero.rs
@@ -1,12 +1,15 @@
 //! Testing mutual conversion between geo_types and our MultiPolygon
 use core::panic;
 
-use flatgeom::{LineString2, MultiLineString2, MultiPolygon2, Polygon2};
+use flatgeom::{
+    geozero::ToFlatgeom, Geometry2, LineString2, MultiLineString2, MultiPoint2, MultiPolygon2,
+    Polygon2,
+};
 
 use geozero::ToGeo;
 
 #[test]
-fn multipolygon_to_geo() {
+fn multipolygon() {
     let mut mpoly = MultiPolygon2::new();
     // 1st polygon
     let mut poly1 = Polygon2::new();
@@ -26,67 +29,143 @@ fn multipolygon_to_geo() {
     poly3.add_ring([[4., 0.], [7., 0.], [7., 3.], [4., 3.]]); // exterior
     mpoly.push(&poly3);
 
+    // Conversion
     let Ok(geo) = mpoly.to_geo() else {
         panic!("Conversion failed");
     };
-    match geo {
+    match &geo {
         geo_types::Geometry::MultiPolygon(geo_mpoly) => {
             assert_eq!(geo_mpoly.0.len(), 3);
             assert_eq!(geo_mpoly.0[0].exterior().0.len(), 5); // ring must be closed
             assert_eq!(geo_mpoly.0[0].interiors().len(), 2);
         }
         _ => panic!("Geometry type must be MultiPolygon"),
+    };
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPolygon(mpoly) => {
+            assert_eq!(mpoly.len(), 3);
+        }
+        _ => panic!("MultiPolygon is expected"),
     }
 }
 
 #[test]
-fn polygon_to_geo() {
+fn polygon() {
     let mut poly = Polygon2::new();
     poly.add_ring([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]); // exterior
     poly.add_ring([[1., 1.], [2., 1.], [2., 2.], [1., 2.]]); // interior
     poly.add_ring([[3., 3.], [4., 3.], [4., 4.], [3., 4.]]); // interior
 
+    // Conversion
     let Ok(geo) = poly.to_geo() else {
         panic!("Conversion failed");
     };
-    match geo {
+    match &geo {
         geo_types::Geometry::Polygon(geo_poly) => {
             assert_eq!(geo_poly.exterior().0.len(), 5); // ring must be closed
             assert_eq!(geo_poly.interiors().len(), 2);
         }
         _ => panic!("Geometry type must be Polygon"),
     }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::Polygon(poly) => {
+            assert_eq!(poly.len(), 3);
+        }
+        _ => panic!("Polygon is expected"),
+    }
 }
 
 #[test]
-fn multilinestring_to_geo() {
+fn multilinestring() {
     let mut mls = MultiLineString2::new();
     mls.add_linestring([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]);
     mls.add_linestring([[1., 0.], [5., 0.], [5., 5.], [0., 5.]]);
     mls.add_linestring([[2., 0.], [5., 0.], [5., 5.], [0., 5.]]);
 
+    // Conversion
     let Ok(geo) = mls.to_geo() else {
         panic!("Conversion failed");
     };
-    match geo {
+    match &geo {
         geo_types::Geometry::MultiLineString(geo_mls) => {
             assert_eq!(geo_mls.0.len(), 3); // ring must be closed
             assert_eq!(geo_mls.0[0].0.len(), 4); // ring must be closed
         }
         _ => panic!("Geometry type must be MultiLineString"),
     }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiLineString(poly) => {
+            assert_eq!(poly.len(), 3);
+        }
+        _ => panic!("MultiLineString is expected"),
+    }
 }
 
 #[test]
-fn linestring_to_geo() {
+fn linestring() {
+    // Conversion
     let ls = LineString2::from_raw(vec![[0., 0.], [5., 0.], [5., 5.], [0., 5.]].into());
     let Ok(geo) = ls.to_geo() else {
         panic!("Conversion failed");
     };
-    match geo {
+    match &geo {
         geo_types::Geometry::LineString(geo_ls) => {
             assert_eq!(geo_ls.0.len(), 4); // ring must be closed
         }
         _ => panic!("Geometry type must be LineString"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::LineString(poly) => {
+            assert_eq!(poly.len(), 4);
+        }
+        _ => panic!("LineString is expected"),
+    }
+}
+
+#[test]
+fn multipoint() {
+    let mut mp = MultiPoint2::new();
+    mp.extend([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]);
+
+    // Conversion
+    let Ok(geo) = mp.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::MultiPoint(geo_mp) => {
+            assert_eq!(geo_mp.len(), 4);
+        }
+        _ => panic!("Geometry type must be MultiPoint"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPoint(mp) => {
+            assert_eq!(mp.len(), 4);
+        }
+        _ => panic!("MultiPoint is expected"),
     }
 }

--- a/tests/geozero.rs
+++ b/tests/geozero.rs
@@ -2,8 +2,8 @@
 use core::panic;
 
 use flatgeom::{
-    geozero::ToFlatgeom, Geometry2, LineString2, MultiLineString2, MultiPoint2, MultiPolygon2,
-    Polygon2,
+    geozero::ToFlatgeom, Geometry2, Geometry3, LineString2, LineString3, MultiLineString2,
+    MultiLineString3, MultiPoint2, MultiPoint3, MultiPolygon2, MultiPolygon3, Polygon2, Polygon3,
 };
 
 use geozero::ToGeo;
@@ -55,6 +55,52 @@ fn multipolygon() {
 }
 
 #[test]
+fn multipolygon3d() {
+    let mut mpoly = MultiPolygon3::new();
+    // 1st polygon
+    let mut poly1 = Polygon3::new();
+    poly1.add_ring([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]); // exterior
+    poly1.add_ring([[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]]); // interior
+    poly1.add_ring([[3., 3., 0.], [4., 3., 0.], [4., 4., 0.], [3., 4., 0.]]); // interior
+    mpoly.push(&poly1);
+
+    // 2nd polygon
+    let mut poly2 = Polygon3::new();
+    poly2.add_ring([[4., 0., 0.], [7., 0., 0.], [7., 3., 0.], [4., 3., 0.]]); // exterior
+    poly2.add_ring([[5., 1., 0.], [6., 1., 0.], [6., 2., 0.], [5., 2., 0.]]); // interior
+    mpoly.push(&poly2);
+
+    // 3rd polygon
+    let mut poly3 = Polygon3::new();
+    poly3.add_ring([[4., 0., 0.], [7., 0., 0.], [7., 3., 0.], [4., 3., 0.]]); // exterior
+    mpoly.push(&poly3);
+
+    // Conversion
+    let Ok(geo) = mpoly.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::MultiPolygon(geo_mpoly) => {
+            assert_eq!(geo_mpoly.0.len(), 3);
+            assert_eq!(geo_mpoly.0[0].exterior().0.len(), 5); // ring must be closed
+            assert_eq!(geo_mpoly.0[0].interiors().len(), 2);
+        }
+        _ => panic!("Geometry type must be MultiPolygon"),
+    };
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPolygon(mpoly) => {
+            assert_eq!(mpoly.len(), 3);
+        }
+        _ => panic!("MultiPolygon is expected"),
+    }
+}
+
+#[test]
 fn polygon() {
     let mut poly = Polygon2::new();
     poly.add_ring([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]); // exterior
@@ -75,6 +121,37 @@ fn polygon() {
 
     // Inversion
     let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::Polygon(poly) => {
+            assert_eq!(poly.len(), 3);
+        }
+        _ => panic!("Polygon is expected"),
+    }
+}
+
+#[test]
+fn polygon3d() {
+    let mut poly = Polygon3::new();
+    poly.add_ring([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]); // exterior
+    poly.add_ring([[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]]); // interior
+    poly.add_ring([[3., 3., 0.], [4., 3., 0.], [4., 4., 0.], [3., 4., 0.]]); // interior
+
+    // Conversion
+    let Ok(geo) = poly.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::Polygon(geo_poly) => {
+            assert_eq!(geo_poly.exterior().0.len(), 5); // ring must be closed
+            assert_eq!(geo_poly.interiors().len(), 2);
+        }
+        _ => panic!("Geometry type must be Polygon"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -117,6 +194,37 @@ fn multilinestring() {
 }
 
 #[test]
+fn multilinestring3d() {
+    let mut mls = MultiLineString3::new();
+    mls.add_linestring([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
+    mls.add_linestring([[1., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
+    mls.add_linestring([[2., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
+
+    // Conversion
+    let Ok(geo) = mls.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::MultiLineString(geo_mls) => {
+            assert_eq!(geo_mls.0.len(), 3); // ring must be closed
+            assert_eq!(geo_mls.0[0].0.len(), 4); // ring must be closed
+        }
+        _ => panic!("Geometry type must be MultiLineString"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiLineString(poly) => {
+            assert_eq!(poly.len(), 3);
+        }
+        _ => panic!("MultiLineString is expected"),
+    }
+}
+
+#[test]
 fn linestring() {
     // Conversion
     let ls = LineString2::from_raw(vec![[0., 0.], [5., 0.], [5., 5.], [0., 5.]].into());
@@ -132,6 +240,33 @@ fn linestring() {
 
     // Inversion
     let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::LineString(poly) => {
+            assert_eq!(poly.len(), 4);
+        }
+        _ => panic!("LineString is expected"),
+    }
+}
+
+#[test]
+fn linestring3d() {
+    // Conversion
+    let ls =
+        LineString3::from_raw(vec![[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]].into());
+    let Ok(geo) = ls.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::LineString(geo_ls) => {
+            assert_eq!(geo_ls.0.len(), 4); // ring must be closed
+        }
+        _ => panic!("Geometry type must be LineString"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -160,6 +295,34 @@ fn multipoint() {
 
     // Inversion
     let Ok(flat): geozero::error::Result<Geometry2> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPoint(mp) => {
+            assert_eq!(mp.len(), 4);
+        }
+        _ => panic!("MultiPoint is expected"),
+    }
+}
+
+#[test]
+fn multipoint3d() {
+    let mut mp = MultiPoint3::new();
+    mp.extend([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
+
+    // Conversion
+    let Ok(geo) = mp.to_geo() else {
+        panic!("Conversion failed");
+    };
+    match &geo {
+        geo_types::Geometry::MultiPoint(geo_mp) => {
+            assert_eq!(geo_mp.len(), 4);
+        }
+        _ => panic!("Geometry type must be MultiPoint"),
+    }
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {

--- a/tests/geozero.rs
+++ b/tests/geozero.rs
@@ -1,6 +1,4 @@
 //! Testing mutual conversion between geo_types and our MultiPolygon
-use core::panic;
-
 use flatgeom::{
     geozero::ToFlatgeom, Geometry2, Geometry3, LineString2, LineString3, MultiLineString2,
     MultiLineString3, MultiPoint2, MultiPoint3, MultiPolygon2, MultiPolygon3, Polygon2, Polygon3,
@@ -75,21 +73,7 @@ fn multipolygon3d() {
     poly3.add_ring([[4., 0., 0.], [7., 0., 0.], [7., 3., 0.], [4., 3., 0.]]); // exterior
     mpoly.push(&poly3);
 
-    // Conversion
-    let Ok(geo) = mpoly.to_geo() else {
-        panic!("Conversion failed");
-    };
-    match &geo {
-        geo_types::Geometry::MultiPolygon(geo_mpoly) => {
-            assert_eq!(geo_mpoly.0.len(), 3);
-            assert_eq!(geo_mpoly.0[0].exterior().0.len(), 5); // ring must be closed
-            assert_eq!(geo_mpoly.0[0].interiors().len(), 2);
-        }
-        _ => panic!("Geometry type must be MultiPolygon"),
-    };
-
-    // Inversion
-    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+    let Ok(flat): geozero::error::Result<Geometry3> = mpoly.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -138,20 +122,7 @@ fn polygon3d() {
     poly.add_ring([[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]]); // interior
     poly.add_ring([[3., 3., 0.], [4., 3., 0.], [4., 4., 0.], [3., 4., 0.]]); // interior
 
-    // Conversion
-    let Ok(geo) = poly.to_geo() else {
-        panic!("Conversion failed");
-    };
-    match &geo {
-        geo_types::Geometry::Polygon(geo_poly) => {
-            assert_eq!(geo_poly.exterior().0.len(), 5); // ring must be closed
-            assert_eq!(geo_poly.interiors().len(), 2);
-        }
-        _ => panic!("Geometry type must be Polygon"),
-    }
-
-    // Inversion
-    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+    let Ok(flat): geozero::error::Result<Geometry3> = poly.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -200,20 +171,7 @@ fn multilinestring3d() {
     mls.add_linestring([[1., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
     mls.add_linestring([[2., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
 
-    // Conversion
-    let Ok(geo) = mls.to_geo() else {
-        panic!("Conversion failed");
-    };
-    match &geo {
-        geo_types::Geometry::MultiLineString(geo_mls) => {
-            assert_eq!(geo_mls.0.len(), 3); // ring must be closed
-            assert_eq!(geo_mls.0[0].0.len(), 4); // ring must be closed
-        }
-        _ => panic!("Geometry type must be MultiLineString"),
-    }
-
-    // Inversion
-    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+    let Ok(flat): geozero::error::Result<Geometry3> = mls.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -252,21 +210,9 @@ fn linestring() {
 
 #[test]
 fn linestring3d() {
-    // Conversion
     let ls =
         LineString3::from_raw(vec![[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]].into());
-    let Ok(geo) = ls.to_geo() else {
-        panic!("Conversion failed");
-    };
-    match &geo {
-        geo_types::Geometry::LineString(geo_ls) => {
-            assert_eq!(geo_ls.0.len(), 4); // ring must be closed
-        }
-        _ => panic!("Geometry type must be LineString"),
-    }
-
-    // Inversion
-    let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+    let Ok(flat): geozero::error::Result<Geometry3> = ls.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {
@@ -310,8 +256,25 @@ fn multipoint3d() {
     let mut mp = MultiPoint3::new();
     mp.extend([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
 
+    let Ok(flat): geozero::error::Result<Geometry3> = mp.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPoint(mp) => {
+            assert_eq!(mp.len(), 4);
+        }
+        _ => panic!("MultiPoint is expected"),
+    }
+}
+
+#[test]
+fn geometry() {
+    let mut mp = MultiPoint2::new();
+    mp.extend([[0., 0.], [5., 0.], [5., 5.], [0., 5.]]);
+    let geom = crate::Geometry2::MultiPoint(mp);
+
     // Conversion
-    let Ok(geo) = mp.to_geo() else {
+    let Ok(geo) = geom.to_geo() else {
         panic!("Conversion failed");
     };
     match &geo {
@@ -323,6 +286,24 @@ fn multipoint3d() {
 
     // Inversion
     let Ok(flat): geozero::error::Result<Geometry3> = geo.to_flatgeom() else {
+        panic!("Conversion failed");
+    };
+    match &flat {
+        flatgeom::Geometry::MultiPoint(mp) => {
+            assert_eq!(mp.len(), 4);
+        }
+        _ => panic!("MultiPoint is expected"),
+    }
+}
+
+#[test]
+fn geometry3d() {
+    let mut mp = MultiPoint3::new();
+    mp.extend([[0., 0., 0.], [5., 0., 0.], [5., 5., 0.], [0., 5., 0.]]);
+    let geom = crate::Geometry3::MultiPoint(mp);
+
+    // Inversion
+    let Ok(flat): geozero::error::Result<Geometry3> = geom.to_flatgeom() else {
         panic!("Conversion failed");
     };
     match &flat {


### PR DESCRIPTION
Close #2

This PR implements the [GeomProcessor](https://docs.rs/geozero/latest/geozero/trait.GeomProcessor.html) trait for our geometries,  enabling the conversion of other GeoZero geometries into our geometries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `extend` methods to `LineString` and `MultiPoint` for appending coordinates.
  - Introduced `GeometryCollection` to handle collections of geometries.
  - Introduced `ToFlatgeom` trait for converting geometries to a flat representation.

- **Enhancements**
  - The public API now includes `reader` and `writer` modules under `geozero`.
  - Enhanced `FlatgeomWriter` to support multi-dimensional geometries and collections.

- **Tests**
  - Updated test functions and import statements to support the new `flatgeom` conversions and additional geometric types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->